### PR TITLE
update output; return solution after interruption

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -589,8 +589,8 @@ struct CLRSResults
 end
 function CLRSResults(x,X,y,Y, primal_objective,dual_objective, matrix_coeff_names::Vector, free_coeff_names::Vector)
     #convert to
-    matrixvar = Dict(Block(m) => BigFloat.(mv) for (m,mv) in zip(matrix_coeff_names[j], Y.blocks[j].blocks) for j=1:length(matrix_coeff_names))
-    freevar = Dict(f => BigFloat(fv) for (f,fv) in zip(y, free_coeff_names))
+    matrixvar = Dict(Block(m) => BigFloat.(mv) for j=1:length(matrix_coeff_names) for (m,mv) in zip(matrix_coeff_names[j], Y.blocks[j].blocks) )
+    freevar = Dict(f => BigFloat(fv) for (f,fv) in zip(free_coeff_names,y))
     return CLRSResults(x,X,y,Y, primal_objective,dual_objective, matrixvar, freevar)
 end
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -568,16 +568,30 @@ optimal(::Optimal) = true
 
 
 #The name to make clear what results these are. Distinguishing it from e.g. SDPA-GMP if someone uses both?
+#TODO: decide whether to change CLRSResults to ClusteredLowRankSolverResults
+#TODO: should we remove the y and the Y now that we gave the names back
+#TODO: should we convert x, X to BigFloat too? or keep matrixvar etc in Arbs?
 struct CLRSResults
+    #the internally used matrices
     x::ArbRefMatrix
     X::BlockDiagonal{ArbRef,BlockDiagonal{ArbRef,ArbRefMatrix}}
     y::ArbRefMatrix
     Y::BlockDiagonal{ArbRef,BlockDiagonal{ArbRef,ArbRefMatrix}}
+    #the objectives
     primal_objective::Arb
     dual_objective::Arb
-    matrix_coeff_names::Vector{Vector{Any}}
-    free_coeff_names::Vector{Any}
+    #the dual solutions with the user-defined names
+    matrixvar::Dict{Block, Matrix{BigFloat}}
+    freevar::Dict{Any, BigFloat}
+    # matrix_coeff_names::Vector{Vector{Any}}
+    # free_coeff_names::Vector{Any}
     # status::Status #optimal, near optimal, primal feasible, dual feasible, feasible (p&d),not converged
+end
+function CLRSResults(x,X,y,Y, primal_objective,dual_objective, matrix_coeff_names::Vector, free_coeff_names::Vector)
+    #convert to
+    matrixvar = Dict(Block(m) => BigFloat.(mv) for (m,mv) in zip(matrix_coeff_names[j], Y.blocks[j].blocks) for j=1:length(matrix_coeff_names))
+    freevar = Dict(f => BigFloat(fv) for (f,fv) in zip(y, free_coeff_names))
+    return CLRSResults(x,X,y,Y, primal_objective,dual_objective, matrixvar, freevar)
 end
 
 Base.show(io::IO, x::Optimal) = @printf(io, "pdOpt")

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -477,7 +477,7 @@ function solvesdp(
         iter += 1
     end
     catch e
-        println("A $(typeof(e)) occurred")
+        println("A(n) $(typeof(e)) occurred.")
         if hasfield(typeof(e),:msg)
             println(e.msg)
         end


### PR DESCRIPTION
@JuliaRegistrator register()

Compared to previous registered version: 
  - Update the output so that the user defined names of the matrices and free variables can be used to access the solution.
  - Remove a rethrow statement so that the program returns the current solution when an error occurs (including Ctrl-C)