### PR TITLE
Reduce memory usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
-            JULIA_NUM_THREADS={{ matrix.threads}}
+          JULIA_NUM_THREADS: {{ matrix.threads}}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
         threads:
           - 1
           - 4
+        exclude:
+          - os: macOS-latest
+            threads: 4
+          - os: windows-latest
+            threads: 4
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
@@ -45,7 +50,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
-          JULIA_NUM_THREADS: ${{ matrix.threads}}
+          JULIA_NUM_THREADS: ${{ matrix.threads }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
           - windows-latest
         arch:
           - x64
+        threads:
+          - 1
+          - 4
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1
@@ -42,9 +45,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
-          matrix:
-            - JULIA_NUM_THREADS=1
-            - JULIA_NUM_THREADS=4
+            JULIA_NUM_THREADS={{ matrix.threads}}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:
-          JULIA_NUM_THREADS: {{ matrix.threads}}
+          JULIA_NUM_THREADS: ${{ matrix.threads}}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,10 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        env:
+          matrix:
+            - JULIA_NUM_THREADS=1
+            - JULIA_NUM_THREADS=4
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
-AbstractAlgebra = "0.24, 0.25, 0.26, 0.27, 0.28"
+AbstractAlgebra = "0.24, 0.25, 0.26, 0.27, 0.28, 0.29, 0.30"
 Arblib = "0.6, 0.7, 0.8"
 BlockDiagonals = "0.1"
 GenericLinearAlgebra = "0.2, 0.3"

--- a/src/ClusteredLowRankSolver.jl
+++ b/src/ClusteredLowRankSolver.jl
@@ -1,12 +1,11 @@
 module ClusteredLowRankSolver
 
 using AbstractAlgebra, IterTools, LinearAlgebra
-# using ApproximateFekete
 using Printf, Arblib, BlockDiagonals
 using KrylovKit
 
-export LowRankMat, LowRankMatPol, Block, Constraint, Objective,	 LowRankPolProblem, ClusteredLowRankSDP, solvesdp, approximatefekete,SampledMPolyElem,optimal
-export solvesdp, convert_to_prec, SolverFailure
+export LowRankMat, LowRankMatPol, Block, Constraint, Objective,	 LowRankPolProblem, ClusteredLowRankSDP, solvesdp, approximatefekete, SampledMPolyElem, optimal
+export convert_to_prec, SolverFailure
 
 import LinearAlgebra: dot, transpose
 import Base: ==

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -707,6 +707,7 @@ function compute_residuals!(sdp, x, X, y, Y, P, p, d,threadinginfo,vecs_left,vec
     p_added = [similar(p) for j in eachindex(sdp.B)]
     Threads.@threads for j in threadinginfo.j_order
         j_idx = sum(size.(sdp.c[1:j-1],1))
+        # Arblib.approx_mul!(p_added[j], transpose(sdp.B[j]), x[j_idx+1:j_idx+size(sdp.c[j],1),:])
         approx_mul_transpose!(p_added[j],sdp.B[j], x[j_idx+1:j_idx+size(sdp.c[j],1),:])
     end
     for j in eachindex(p_added)
@@ -1232,6 +1233,7 @@ function compute_weighted_A!(initial_matrix, sdp, a,vecs_left,high_ranks)
     # initial_matrix is a BlockDiagonal matrix of BlockDiagonal matrices of ArbMatrices
     # We add the contributions to the (blocked) upper triangular, then symmetrize
     Q = ArbRefMatrix(0,0,prec=precision(a))
+    w = ArbRefMatrix(0,0,prec=precision(a))
     j_idx = 0
     for j in eachindex(sdp.A)
         for l in eachindex(sdp.A[j])
@@ -1366,6 +1368,7 @@ function compute_search_direction!(
                 0,
             )
             Arblib.get_mid!(temp_x[j],temp_x[j])
+            # Arblib.approx_mul!(temp_y[j], transpose(LinvB[j]), temp_x[j])
             approx_mul_transpose!(temp_y[j], LinvB[j], temp_x[j])
         end
 

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -999,7 +999,7 @@ function compute_S_integrated!(S,sdp,A_Y, X_inv, Y,bilinear_pairings_Y, bilinear
                     matmul_threaded!(part_r, temp_window, rightvecs[j][l][r], prec=matmul_prec)
                     Arblib.window_clear!(temp_window)
                     Arblib.get_mid!(part_r, part_r)
-                    for s=1:r
+                    for s=1:size(sdp.A[j][l],1)
                         Arblib.window_init!(temp_window, part_r, (s-1)*delta, 0, s*delta, size(part_r,2))
                         Arblib.window_init!(temp_window2, bilinear_pairings_Y[s,r], 0, 0, size(leftvecs[j][l][s],1), size(part_r,2))
                         matmul_threaded!(temp_window2, leftvecs[j][l][s], temp_window, prec=matmul_prec)#,opt=4)
@@ -1011,10 +1011,9 @@ function compute_S_integrated!(S,sdp,A_Y, X_inv, Y,bilinear_pairings_Y, bilinear
                     matmul_threaded!(part_r, temp_window, rightvecs[j][l][r], prec=matmul_prec)
                     Arblib.window_clear!(temp_window)
                     Arblib.get_mid!(part_r, part_r)
-                    for s=1:r
+                    for s=1:size(sdp.A[j][l],1)
                         Arblib.window_init!(temp_window, part_r, (s-1)*delta, 0, s*delta, size(part_r,2))
                         Arblib.window_init!(temp_window2, bilinear_pairings_Xinv[s,r], 0, 0, size(leftvecs[j][l][s],1), size(part_r,2))
-
                         matmul_threaded!(temp_window2,leftvecs[j][l][s],temp_window,prec=matmul_prec)#,opt=4)
                         Arblib.window_clear!(temp_window)
                         Arblib.window_clear!(temp_window2)
@@ -1041,19 +1040,11 @@ function compute_S_integrated!(S,sdp,A_Y, X_inv, Y,bilinear_pairings_Y, bilinear
                             for rnk=1:length(sdp.A[j][l][r,s][p].eigenvalues)
                                 #This way we have A_Y in the order of [for p in Ps for i=1:rank]
                                 # here we take the transpose element, since we only have the bilinear pairings for r <= s
-                                try 
-                                if r != s
-                                    A_Y[j][l][r,s][idx,1] = bilinear_pairings_Y[s,r][pointers_right[j][l][s][(r,p,rnk)], pointers_left[j][l][r][(s,p,rnk)]]
-                                else
-                                    A_Y[j][l][r,s][idx,1] = bilinear_pairings_Y[r,s][pointers_left[j][l][r][(s,p,rnk)], pointers_right[j][l][s][(r,p,rnk)]]
-                                end
-                                catch e
-                                    @show j,l,r,s,p,rnk,idx
-                                    @show size(bilinear_pairings_Y[r,s])
-                                    @show pointers_left[j][l][r][(s,p,rnk)]
-                                    @show pointers_right[j][l][s][(r,p,rnk)]
-                                    rethrow(e)
-                                end
+                                # if r != s
+                                #     A_Y[j][l][r,s][idx,1] = bilinear_pairings_Y[s,r][pointers_right[j][l][s][(r,p,rnk)], pointers_left[j][l][r][(s,p,rnk)]]
+                                # else
+                                A_Y[j][l][r,s][idx,1] = bilinear_pairings_Y[r,s][pointers_left[j][l][r][(s,p,rnk)], pointers_right[j][l][s][(r,p,rnk)]]
+                                # end
                                 # end
                                 idx+=1
                             end

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -225,7 +225,8 @@ function thread_func_inner_window!(C::T,A::T,B::T;n=Threads.nthreads(),prec=prec
         Arblib.window_clear!(parts_A[i])
         Arblib.window_clear!(parts_B[i])
     end
-    for i=1:n
+    Arblib.set!(C, part_res[1])
+    for i=2:n
         Arblib.add!(C, C, part_res[i])
     end
 end

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -126,11 +126,12 @@ function unique(x::Vector{T}) where T<:Union{ArbMatrix,ArbRefMatrix}
     return x[unique_idx]
 end
 
-function approx_mul_transpose(C::T, AT::T, B::T; prec=precision(C)) where T<:Union{ArbMatrix,ArbRefMatrix}
+function approx_mul_transpose!(C::T, AT::T, B::T; prec=precision(C)) where T<:Union{ArbMatrix,ArbRefMatrix}
     # C = AT^T * B = (B^T * AT)^T
     #assume that AT is much larger than B (e.g., matrix * vector)
     BT = T(size(B,2), size(B,1), prec=precision(B))
-    res = T(size(AT, 2), size(B,2), prec=prec)
+    res = T(size(C, 2), size(C,1), prec=prec)
+    Arblib.transpose!(BT, B)
     Arblib.approx_mul!(res,BT,AT)
     Arblib.transpose!(C, res)
 end

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -136,13 +136,14 @@ function matmul_threaded!(C::T, A::T, B::T; n = Threads.nthreads(), prec=precisi
     #check dimensions
     @assert size(C,1) == size(A,1) && size(C,2) == size(B,2) && size(A,2) == size(B,1)
     #check for the special case of 1 thread:
-    if n==1 || size(A,1)*size(A,2)*size(B,2) * div(prec,256) < 1000
+    if n==1 || size(A,1)*size(A,2)*size(B,2) * div(prec,256) < 6^3
         #TODO: determine up to what sizes (& what number of threads) running multithreaded is better than threaded.
         return Arblib.approx_mul!(C,A,B,prec=prec)
     end
     # determine how to do threading
-    if !(opt in [1,2,3,4])
-        opt = argmax([size(B,2),size(A,1),size(A,2)])
+    if !(opt in [1,2,3])
+        #we don't really want to do the inner (option 3), but if that size is more than twice as large, we do that.
+        opt = argmax([size(B,2),size(A,1),1//2*size(A,2)]) 
     end
 
     # opt == 1 => distribute the columns of B over threads (preferred above rows when equal due to julia/arb being column-major)
@@ -150,134 +151,72 @@ function matmul_threaded!(C::T, A::T, B::T; n = Threads.nthreads(), prec=precisi
     # opt == 3 => distribute the columns of A/rows of B over threads and add the results
     # Option 1 and 2 are preferred above 3, because in those cases we don't have to add matrices. argmax gives the first maximal element
     # for now, we'll just do one of the options. Maybe in some cases it is better to have for example a 3x3 grid instead of 1x9, so to use multiple options instead of 1
-    # That will just be generating different idx_rows, idx_cols and inner stuff
-
     if opt == 1
-        thread_func_right!(C,A,B,Arblib.approx_mul!,prec=prec)
-        return C
-    else
-        idx_cols = [1:size(B,2) for i=1:n]
-    end
-    if opt == 2
-        thread_func_left!(C,A,B,Arblib.approx_mul!,prec=prec)
-        return C
-    else
-        idx_rows = [1:size(A,1) for i=1:n]
-    end
-
-    #If we are threading over the outer part, we only need one result. So n_inner gives the number of results, idx_inner gives the indices thread i uses, res_idx gives which result is used
-    if opt == 3
-        n_inner = n
-        nr = size(A,2)
-        # every thread gets at least floor(nr/n) rows, and we add the remaining parts until they are all distributed
-        sizes = [div(nr,n_inner) for i=1:n_inner] .+ [div(nr,n_inner)*n_inner+i <= nr ? 1 : 0 for i=1:n_inner]
-        idxs = [0, cumsum(sizes)...]
-        idx_inner = [idxs[i]+1:idxs[i+1] for i=1:n_inner]
-        res_idx = [i for i=1:n_inner]
-    else
-        n_inner = 1
-        idx_inner = [1:size(A,2) for i=1:n]
-        res_idx = [1 for i=1:n]
-    end
-
-    if opt == 4 #both over rows and columns, no inner. This option can only be chosen manually. It seems to be far less efficient
-        # we want the blocks to be about square. So we need to find numbers a, b such that rows/a ≈ cols/b and a*b ≈ n
-        if size(C,1) == size(C,2) #square, so we take squareroot
-            sqrtn = isqrt(n) #integer squareroot, so sqrtn^2 < n probably. We
-            if sqrtn^2 != n
-                a = sqrtn
-                b = sqrtn+1
-            else
-                a = b = sqrtn
-            end
-        else
-            r = size(C,1)
-            c = size(C,2)
-            a = isqrt(div(n*r,c))
-            b = div(n,a)
-            #it is possible that we can increase a by one while keeping a*b <= n
-            a = max(a, div(n,b))
-        end
-        n = a*b #new n based on the partition
-
-        rsizes =  [div(size(C,1),a) for i=1:a] .+ [div(size(C,1),a)*a+i <= size(C,1) ? 1 : 0 for i=1:a]
-        ridxs = [0, cumsum(rsizes)...]
-        idx_rows_part = [ridxs[i]+1:ridxs[i+1] for i=1:a]
-
-        csizes =  [div(size(C,2),b) for i=1:b] .+ [div(size(C,2),b)*b+i <= size(C,2) ? 1 : 0 for i=1:b]
-        cidxs = [0, cumsum(csizes)...]
-        idx_cols_part = [cidxs[i]+1:cidxs[i+1] for i=1:b]
-
-        #final partition: iteration i does block C[idx_rows[i],idx_cols[i]]
-        idx_rows = [idx_rows_part[div(i,b)+1] for i=0:n-1]
-        idx_cols = [idx_cols_part[i%b+1] for i=0:n-1]
-
-        n_inner = 1
-        idx_inner = [1:size(A,2) for i=1:n]
-        res_idx = [1 for i=1:n]
-    end
-
-    # Do the threaded matrix multiplication
-    # We could use 1 matrix less if we use C with n_inner > 1 too.
-    if n_inner > 1
-        res_matrices = [T(size(C,1),size(C,2),prec=prec) for i=1:n_inner]
-    end
-    part_res = [T(length(idx_rows[i]),length(idx_cols[i]),prec=prec) for i=1:n] # when n_inner =1, this is max one copy of C
-    As = [A[idx_rows[i],idx_inner[i]] for i=1:n] #in total max n copies of A, but in total 1 copy if n_inner = 1
-    Bs = [B[idx_inner[i],idx_cols[i]] for i=1:n] # in total max n copies of B
-    Threads.@threads for i=1:n
-        # cur_res = T(length(idx_rows[i]),length(idx_cols[i]),prec=prec)
-        # I am not sure whether allocating inside a threaded loop + finalizers can give memory leakage.
-        # for ArbMatrices we would probably want to use the ref versions of the slice & set operations
-        # Arblib.approx_mul!(part_res[i],A[idx_rows[i],idx_inner[i]],B[idx_inner[i],idx_cols[i]]) #do we want to use a different mul here?
-        Arblib.approx_mul!(part_res[i],As[i],Bs[i])
-        if n_inner > 1 # race conditions if we set/add to C directly, so we set the parts
-            res_matrices[res_idx[i]][idx_rows[i],idx_cols[i]] = part_res[i]
-        else
-            C[idx_rows[i],idx_cols[i]] = part_res[i] # we actually would want to use a view/window of C[...,...] for the matrix product. But the Arblib window does not work nicely due to init/clear and normal view does not work with ArbMatrices.
-        end
-    end
-
-    #add the results if needed
-    if n_inner > 1
-        # this way we don't have to zero C, we do that implicitely.
-        # if n_inner>1, then we at least have 2 matrices to add
-        Arblib.add!(C,res_matrices[1],res_matrices[2],prec=prec)
-        for i=3:n_inner
-            Arblib.add!(C,C,res_matrices[i],prec=prec)
-        end
+        thread_func_right_window!(C,A,B,prec=prec)
+    elseif opt == 2
+        thread_func_left_window!(C,A,B,prec=prec)
+    elseif opt == 3
+        thread_func_inner_window!(C,A,B,prec=prec)
     end
     return C
 end
-function thread_func_right!(C::T,A::T,B::T,func!;n=Threads.nthreads(),prec=precision(C)) where T <: AbstractMatrix
+
+function thread_func_inner_window!(C::T,A::T,B::T;n=Threads.nthreads(),prec=precision(C)) where T <: Union{ArbMatrix, ArbRefMatrix}
     # distribute B over several cores and apply func!(C[part],A,B[part],prec=prec)
-    nc = size(B,2)
+    nc = size(B,1)
     sizes = [div(nc,n) for i=1:n] .+ [div(nc,n)*n+i <= nc ? 1 : 0 for i=1:n]
     idxs = [0, cumsum(sizes)...]
-    idx_cols = [idxs[i]+1:idxs[i+1] for i=1:n]
+    # idx_cols = [idxs[i]+1:idxs[i+1] for i=1:n]
 
-    parts_B = [B[:,idx_cols[i]] for i=1:n]
-    part_res = [T(size(C,1),length(idx_cols[i]),prec=prec) for i=1:n] # when n_inner =1, this is max one copy of C
+    parts_A = [T(0,0) for i=1:n]
+    parts_B = [T(0,0) for i=1:n]
+    part_res = [similar(C) for i=1:n] # when n_inner =1, this is max one copy of C
     Threads.@threads for i=1:n
-        func!(part_res[i],A,parts_B[i],prec=prec)
-        C[:,idx_cols[i]] = part_res[i]
+        Arblib.window_init!(parts_A[i], A, 0,idxs[i], size(A,1), idxs[i+1])
+        Arblib.window_init!(parts_B[i], B, idxs[i],0, idxs[i+1], size(B,2))
+        Arblib.approx_mul!(part_res[i],parts_A[i],parts_B[i],prec=prec)
+        Arblib.window_clear!(parts_A[i])
+        Arblib.window_clear!(parts_B[i])
+    end
+    for i=1:n
+        Arblib.add!(C, C, part_res[i])
     end
 end
-
-function thread_func_left!(C::T,A::T,B::T,func!;n=Threads.nthreads(),prec=precision(C)) where T <: AbstractMatrix
+function thread_func_left_window!(C::T,A::T,B::T;n=Threads.nthreads(),prec=precision(C)) where T <: Union{ArbMatrix, ArbRefMatrix}
     # distribute B over several cores and apply func!(C[part],A,B[part],prec=prec)
     nr = size(A,1)
     sizes = [div(nr,n) for i=1:n] .+ [div(nr,n)*n+i <= nr ? 1 : 0 for i=1:n]
     idxs = [0, cumsum(sizes)...]
-    idx_rows = [idxs[i]+1:idxs[i+1] for i=1:n]
+    # idx_rows = [idxs[i]+1:idxs[i+1] for i=1:n]
 
-    parts_A = [A[idx_rows[i],:] for i=1:n]
-    part_res = [T(length(idx_rows[i]),size(C,2),prec=prec) for i=1:n] # when n_inner =1, this is max one copy of C
+    parts_A = [T(0,0) for i=1:n]
+    part_res = [T(0,0) for i=1:n] # when n_inner =1, this is max one copy of C
     Threads.@threads for i=1:n
-        func!(part_res[i],parts_A[i],B,prec=prec)
-        C[idx_rows[i],:] = part_res[i]
+        Arblib.window_init!(parts_A[i], A, idxs[i], 0, idxs[i+1], size(A,2))
+        Arblib.window_init!(part_res[i], C, idxs[i], 0, idxs[i+1], size(C,2))
+        Arblib.approx_mul!(part_res[i],parts_A[i],B,prec=prec)
+        Arblib.window_clear!(parts_A[i])
+        Arblib.window_clear!(part_res[i])
     end
 end
+
+function thread_func_right_window!(C::T,A::T,B::T; n =Threads.nthreads(), prec=precision(C)) where T <: Union{ArbMatrix, ArbRefMatrix}
+    # distribute B over several cores and apply func!(C[part],A,B[part],prec=prec)
+    nc = size(B,2)
+    sizes = [div(nc,n) for i=1:n] .+ [div(nc,n)*n+i <= nc ? 1 : 0 for i=1:n]
+    idxs = [0, cumsum(sizes)...]
+
+    parts_B = [T(0,0, prec=prec) for i=1:n]
+    part_res = [T(0,0,prec=prec) for i=1:n] # when n_inner =1, this is max one copy of C
+    Threads.@threads for i=1:n
+        Arblib.window_init!(parts_B[i], B, 0, idxs[i], size(B,1), idxs[i+1])
+        Arblib.window_init!(part_res[i], C, 0, idxs[i], size(C,1), idxs[i+1])
+        Arblib.approx_mul!(part_res[i],A,parts_B[i],prec=prec)
+        Arblib.window_clear!(parts_B[i])
+        Arblib.window_clear!(part_res[i])
+    end
+end
+
 
 function malloc_trim(k::Int)
     if Sys.islinux()

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -107,7 +107,7 @@ function approx_cholesky!(A::ArbRefMatrix;prec=precision(A))
 end
 
 
-function unique(x::Vector{T}) where T<:Union{ArbMatrix,ArbRefMatrix}
+function unique_idx(x::Vector{T}) where T<:Union{ArbMatrix,ArbRefMatrix}
     unique_idx = Int[]
     for i=1:length(x)
         #We compare this one with the elements we did already
@@ -123,7 +123,7 @@ function unique(x::Vector{T}) where T<:Union{ArbMatrix,ArbRefMatrix}
             push!(unique_idx,i)
         end
     end
-    return x[unique_idx]
+    return unique_idx
 end
 
 function approx_mul_transpose!(C::T, AT::T, B::T; prec=precision(C)) where T<:Union{ArbMatrix,ArbRefMatrix}

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -126,6 +126,15 @@ function unique(x::Vector{T}) where T<:Union{ArbMatrix,ArbRefMatrix}
     return x[unique_idx]
 end
 
+function approx_mul_transpose(C::T, AT::T, B::T; prec=precision(C)) where T<:Union{ArbMatrix,ArbRefMatrix}
+    # C = AT^T * B = (B^T * AT)^T
+    #assume that AT is much larger than B (e.g., matrix * vector)
+    BT = T(size(B,2), size(B,1), prec=precision(B))
+    res = T(size(AT, 2), size(B,2), prec=prec)
+    Arblib.approx_mul!(res,BT,AT)
+    Arblib.transpose!(C, res)
+end
+
 function matmul_threaded!(C::T, A::T, B::T; n = Threads.nthreads(), prec=precision(C), opt::Int=0) where T<:Union{ArbMatrix, ArbRefMatrix}
     # matrix multiplication C = A*B, using multithreading.
     # Note that this is not the same as Arblib.mul_threaded!(), because that uses the classical matrix multiplication with flint threads

--- a/src/tools.jl
+++ b/src/tools.jl
@@ -293,21 +293,4 @@ precision(P::BlockDiagonal) = precision(P.blocks[1]) #we assume that all blocks 
 precision(x) = Base.precision(x) #for other things, just use the Base version
 
 
-function F3(A1,X::T, A2,Y::T) where T<:Union{ArbMatrix, ArbRefMatrix}
-    # compute dot(A, B*C*D) in with A1,A2 sparse (in sparse formate of SparseArrays)
-    res = Arb(0)
-    I1,J1,V1 = findnz(A1)
-    I2,J2,V2 = findnz(A2)
-    tmp = Arb(0)
-    tmp2 = Arb(0)
-    for (i1,j1,v1) in zip(I1,J1,V1)
-        Arblib.zero!(tmp2)
-        for (i2,j2,v2) in zip(I2,J2,V2)
-            Arblib.zero!(tmp)
-            Arblib.mul!(tmp,X[i2,i1], Y[j2,j1])
-            Arblib.addmul!(tmp2,tmp, v2)
-        end
-        Arblib.addmul!(res, tmp2, v1)
-    end
-    return res
-end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,14 +23,14 @@ using Test
 
         include("../examples/SpherePacking.jl")
         using .SpherePacking
-        _, sol, _, _ = cohnelkies(8, 25)
+        _, sol, _, _ = cohnelkies(8, 15, prec=256)
         @test sol.dual_objective ≈ BigFloat(pi)^4/384 atol=1e-4 #exact in the limit of d-> ∞, but for this d the error still is relatively large
-        _, sol, _, _ = Nsphere_packing(8, 15, [1//2,1//2],2)
+        _, sol, _, _ = Nsphere_packing(8, 15, [1//2,1//2],2, prec=256)
         @test sol.dual_objective ≈ BigFloat(pi)^4/384 atol=1e-4
 
         include("../examples/ThreePointBound.jl")
         using .ThreePointBound
-        _, sol, _, _ = three_point_spherical_cap(3, 6, 1//2, 256)
+        _, sol, _, _ = three_point_spherical_cap(3, 6, 1//2, 256, omega_d = 10^3, omega_p=10^3)
         @test sol.dual_objective ≈ 12.718780 atol=1e-5
     end
 


### PR DESCRIPTION
Reduce the memory usage by using the Arblib equivalent of views, and reusing more matrices. Add multithreading to CI.